### PR TITLE
RD-6422: Add ami_regions variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ export SSH_USERNAME=ec2-user
 export AWS_ACCESS_KEY_ID='Your AWS access key ID'
 export AWS_SECRET_ACCESS_KEY='Your AWS secret access key'
 ```
-You can also optionally export a value for AMI_GROUPS to define what groups have permission to launch the AMI. Be default no groups have permissions, whereas setting to 'all' makes the AMI publicly accessible. 
+***Optional***: Export a value for `AMI_GROUPS` to define what groups have permission to launch the AMI. Be default no groups have permissions, whereas setting to 'all' makes the AMI publicly accessible.
+
+***Optional***: Export a value for `AMI_REGIONS` to define the regions to copy the resulting AMI to. If not defined, the AMI is only saved to the same region used to create the AMI (defined via the `REGION` variable).
 
 Check to verify that your packer file is properly formatted:  
 ```
@@ -53,19 +55,4 @@ packer build -var-file=variables.json packer-centos-ami.json
 After the successful execution of above command, you should see the new AMI created under the AMI section of the EC2 service on AWS.  
 You should also see the scan reports under the S3 service of AWS within the bucket defined in your environment variables above (in this example `hailstone-ami-scan-results`).
 
-
 ===========================================
-
-### To create a new hardened AMI
-
-Whenever a Pull Request is created with reference to master branch, All checks should pass before one can review the code.
-
-After tests are successful, we should see Jenkins build running in our CA Jenkins (Hailstone folder) which will do all of the above steps ( Create an EC2 instance, Connect via SSH, Run security scans (OpenSCAP - OVAL and STIG), Push the reports to S3, Stop the Instance, Create an AMI, Terminate an EC2 instance )
-
-
-### NOTE -
-
-When you add some documentation to README file and ssg-rhel7-ds-justifications.yaml, Jenkins will run a build and create an AMI in AWS.
-
-### To Do -
-A shell script can be created to launch packer build to ease the process. The script can also check  before build if any required variable is missing and guide use for the same.

--- a/packer-centos-ami.json
+++ b/packer-centos-ami.json
@@ -17,6 +17,7 @@
       "ssh_username": "{{user `ssh_username`}}",
       "ami_name": "centos-hardened-{{timestamp}}",
       "ami_groups": "{{user `ami_groups`}}",
+      "ami_regions": "{{user `ami_regions`}}",
       "ssh_keypair_name": "{{user `keypair_name`}}",
       "iam_instance_profile": "{{user `iam_instance_profile`}}",
       "ssh_private_key_file": "{{user `key_file_path`}}",

--- a/packer-rhel7-ami.json
+++ b/packer-rhel7-ami.json
@@ -20,6 +20,7 @@
     "ssh_pty": "true",
     "ami_name": "RHEL7-hardened-{{isotime \"2006-01-02-1504\"}}",
     "ami_groups": "{{user `ami_groups`}}",
+    "ami_regions": "{{user `ami_regions`}}",
     "iam_instance_profile": "{{user `iam_instance_profile`}}",
     "associate_public_ip_address": true,
     "tags": {

--- a/variables.json
+++ b/variables.json
@@ -5,6 +5,7 @@
     "instance_type": "{{env `INSTANCE_TYPE`}}",
     "keypair_name": "{{env `KEYPAIR_NAME`}}",
     "ami_groups": "{{env `AMI_GROUPS`}}",
+    "ami_regions": "{{env `AMI_REGIONS`}}",
     "iam_instance_profile": "{{env `IAM_INSTANCE_PROFILE`}}",
     "key_file_path": "{{env `KEY_FILE_PATH`}}",
     "aws_access_key": "{{env `AWS_ACCESS_KEY_ID`}}",


### PR DESCRIPTION
Add support for utilizing ami_regions to denote target destination AWS regions for the resulting hardened AMI