### PR TITLE
rd-6922 - install newer v1 awscli

### DIFF
--- a/setup-rhel8-custom-auditd.sh
+++ b/setup-rhel8-custom-auditd.sh
@@ -19,8 +19,8 @@ echo "****  Installing PIP   ****"
 yum install -y curl python3
 curl https://bootstrap.pypa.io/pip/3.6/get-pip.py -o get-pip.py
 python3 get-pip.py
-echo "****  installing awscli version 1.16.5   ****"
-/usr/local/bin/pip3 install --user awscli==1.16.5
+echo "****  installing awscli version 1.24.10  ****"
+/usr/local/bin/pip3 install --user awscli==1.24.10
 
 echo "****  Updating OS     ****"
 yum -y install yum-utils


### PR DESCRIPTION
In order to use `aws ec2 modify-address-attribute` in GNET, the version of awscli needs to be bumped. Installing v2 met with some issues we will need to resolve later (exe would not run, SELinux did not appear to be an issue but something was blocking it) so I just installed a newer v1 executable via pip. 