### PR TITLE
rd-7500-grub-openscap-findings - set vsyscall=none and pti=on

### DIFF
--- a/setup-rhel8-custom-auditd.sh
+++ b/setup-rhel8-custom-auditd.sh
@@ -50,7 +50,10 @@ chown root:root /etc/audit/rules.d/custom_privileged.rules
 chmod 0640 /etc/audit/rules.d/custom_privileged.rules
 
 echo "****    Running Remediation steps   ****"
-
+# CAT 2 STIG Finding - V-230278
+grubby --update-kernel=ALL --args="vsyscall=none"
+# CAT 3 STIG Finding - V-230491
+grubby --update-kernel=ALL --args="pti=on"
 
 echo "****    Running firewalld remediation   ****"
 firewall-cmd || yum install firewalld -y


### PR DESCRIPTION
Combined work for RD-7500 and RD-7502, both changes requiring additional GRUB parameters.